### PR TITLE
feat: Add Twitch stream models and API endpoint

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,11 @@
 PODS:
+  - connectivity_plus (0.0.1):
+    - Flutter
+    - ReachabilitySwift
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - ReachabilitySwift (5.0.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -9,12 +13,19 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
+SPEC REPOS:
+  trunk:
+    - ReachabilitySwift
+
 EXTERNAL SOURCES:
+  connectivity_plus:
+    :path: ".symlinks/plugins/connectivity_plus/ios"
   Flutter:
     :path: Flutter
   flutter_secure_storage:
@@ -25,11 +36,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  connectivity_plus: 07c49e96d7fc92bc9920617b83238c4d178b446a
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
+  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/lib/api/twitch_api.dart
+++ b/lib/api/twitch_api.dart
@@ -4,6 +4,7 @@ import "package:chitchat/models/badges/twitch_badge.dart";
 import "package:chitchat/models/emotes/emote.dart";
 import "package:chitchat/models/emotes/twitch_emote.dart";
 import "package:chitchat/models/twitch_channel.dart";
+import "package:chitchat/models/twitch_stream.dart";
 import "package:chitchat/models/twitch_user.dart";
 import "package:flutter/material.dart";
 import "package:http/http.dart";
@@ -207,6 +208,25 @@ class TwitchApi {
     }
 
     return Future.error("Could not fetch stream info");
+  }
+
+  Future<TwitchStreams> getFollowedStreams({
+    required String id,
+    required Map<String, String> headers,
+    String? cursor,
+  }) async {
+    final url = Uri.parse(cursor == null
+        ? "$_helixBase/streams/followed?user_id=$id"
+        : "$_helixBase/streams/followed?user_id=$id&after=$cursor");
+
+    final response = await _client.get(url, headers: headers);
+    final decoded = jsonDecode(response.body);
+    if (response.statusCode == 200) {
+      return TwitchStreams.fromJson(decoded);
+    }
+
+    return Future.error(
+        "Failed to get followed streams: ${decoded["message"]}");
   }
 
   Future<bool> validateUserToken({required String userToken}) async {

--- a/lib/models/twitch_stream.dart
+++ b/lib/models/twitch_stream.dart
@@ -1,0 +1,49 @@
+import "package:json_annotation/json_annotation.dart";
+
+part "twitch_stream.g.dart";
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class TwitchStream {
+  final String userId;
+  final String userLogin;
+  final String userName;
+  final String gameId;
+  final String gameName;
+  final String title;
+  final int viewerCount;
+  final String startedAt;
+  final String thumbnailUrl;
+
+  const TwitchStream(
+    this.userId,
+    this.userLogin,
+    this.userName,
+    this.gameId,
+    this.gameName,
+    this.title,
+    this.viewerCount,
+    this.startedAt,
+    this.thumbnailUrl,
+  );
+
+  factory TwitchStream.fromJson(Map<String, dynamic> json) =>
+      _$TwitchStreamFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TwitchStreamToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class TwitchStreams {
+  final List<TwitchStream> data;
+  final Map<String, String> pagination;
+
+  const TwitchStreams(
+    this.data,
+    this.pagination,
+  );
+
+  factory TwitchStreams.fromJson(Map<String, dynamic> json) =>
+      _$TwitchStreamsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TwitchStreamsToJson(this);
+}

--- a/lib/models/twitch_stream.g.dart
+++ b/lib/models/twitch_stream.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'twitch_stream.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TwitchStream _$TwitchStreamFromJson(Map<String, dynamic> json) => TwitchStream(
+      json['user_id'] as String,
+      json['user_login'] as String,
+      json['user_name'] as String,
+      json['game_id'] as String,
+      json['game_name'] as String,
+      json['title'] as String,
+      json['viewer_count'] as int,
+      json['started_at'] as String,
+      json['thumbnail_url'] as String,
+    );
+
+Map<String, dynamic> _$TwitchStreamToJson(TwitchStream instance) =>
+    <String, dynamic>{
+      'user_id': instance.userId,
+      'user_login': instance.userLogin,
+      'user_name': instance.userName,
+      'game_id': instance.gameId,
+      'game_name': instance.gameName,
+      'title': instance.title,
+      'viewer_count': instance.viewerCount,
+      'started_at': instance.startedAt,
+      'thumbnail_url': instance.thumbnailUrl,
+    };
+
+TwitchStreams _$TwitchStreamsFromJson(Map<String, dynamic> json) =>
+    TwitchStreams(
+      (json['data'] as List<dynamic>)
+          .map((e) => TwitchStream.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      Map<String, String>.from(json['pagination'] as Map),
+    );
+
+Map<String, dynamic> _$TwitchStreamsToJson(TwitchStreams instance) =>
+    <String, dynamic>{
+      'data': instance.data,
+      'pagination': instance.pagination,
+    };

--- a/lib/screens/home/add_tab_screen.dart
+++ b/lib/screens/home/add_tab_screen.dart
@@ -1,4 +1,9 @@
+import "package:chitchat/api/twitch_api.dart";
+import "package:chitchat/models/twitch_stream.dart";
+import "package:chitchat/screens/home/stream_card.dart";
+import "package:chitchat/stores/auth_store.dart";
 import "package:flutter/material.dart";
+import "package:provider/provider.dart";
 
 class AddTabScreen extends StatefulWidget {
   final void Function(String channelName)? onAdd;
@@ -10,7 +15,48 @@ class AddTabScreen extends StatefulWidget {
 }
 
 class _AddTabScreenState extends State<AddTabScreen> {
+  var loadingStreams = true;
+  var loadingMoreStreams = false;
   var channelName = "";
+
+  TwitchStreams? streams;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchStreams();
+  }
+
+  Future<void> _fetchStreams({String? cursor}) async {
+    final authStore = context.read<AuthStore>();
+    final twitchApi = context.read<TwitchApi>();
+
+    if (authStore.userStore.user == null) {
+      return;
+    }
+
+    try {
+      final fetchedStreams = await twitchApi.getFollowedStreams(
+        id: authStore.userStore.user!.id,
+        headers: authStore.twitchHeaders,
+        cursor: cursor,
+      );
+
+      if (cursor != null && streams != null) {
+        fetchedStreams.data.insertAll(0, streams!.data);
+        streams = fetchedStreams;
+      } else {
+        streams = fetchedStreams;
+      }
+
+      setState(() {
+        loadingStreams = false;
+        loadingMoreStreams = false;
+      });
+    } catch (e) {
+      debugPrint("Error fetching followed streams: $e");
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,12 +69,13 @@ class _AddTabScreenState extends State<AddTabScreen> {
           onPressed: Navigator.of(context).pop,
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.only(top: 48.0, left: 16.0, right: 16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            TextField(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0, left: 16.0, right: 16.0),
+            child: TextField(
               decoration: const InputDecoration(
                 hintText: "Enter a channel name",
               ),
@@ -41,8 +88,11 @@ class _AddTabScreenState extends State<AddTabScreen> {
                 Navigator.of(context).pop();
               },
             ),
-            const SizedBox(height: 16.0),
-            FilledButton(
+          ),
+          const SizedBox(height: 16.0),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: FilledButton(
               style: FilledButton.styleFrom(
                 minimumSize: const Size.fromHeight(50),
               ),
@@ -55,8 +105,94 @@ class _AddTabScreenState extends State<AddTabScreen> {
               },
               child: const Text("Add channel"),
             ),
-          ],
-        ),
+          ),
+          const Divider(height: 36.0),
+          Padding(
+            padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 8),
+            child: Row(
+              children: [
+                const Text(
+                  "Followed channels",
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
+                ),
+                const Spacer(),
+                IconButton(
+                  icon: const Icon(Icons.refresh_rounded),
+                  onPressed: loadingStreams || loadingMoreStreams
+                      ? null
+                      : () {
+                          setState(() {
+                            loadingStreams = true;
+                          });
+                          _fetchStreams();
+                        },
+                ),
+              ],
+            ),
+          ),
+          if (loadingStreams)
+            const Padding(
+              padding: EdgeInsets.only(top: 16.0),
+              child: Center(child: CircularProgressIndicator()),
+            )
+          else
+            Expanded(
+              child: ListView.builder(
+                itemCount: (streams?.data.length ?? 0) +
+                    (streams?.pagination["cursor"] != null ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index == streams?.data.length &&
+                      streams?.pagination["cursor"] != null) {
+                    return ListTile(
+                      title: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Text(
+                            "Load more",
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          if (loadingMoreStreams)
+                            const Padding(
+                              padding: EdgeInsets.only(left: 8.0),
+                              child: SizedBox(
+                                width: 20,
+                                height: 20,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 3),
+                              ),
+                            )
+                        ],
+                      ),
+                      onTap: loadingMoreStreams
+                          ? null
+                          : () {
+                              setState(() {
+                                loadingMoreStreams = true;
+                              });
+
+                              _fetchStreams(
+                                  cursor: streams!.pagination["cursor"]);
+                            },
+                    );
+                  }
+
+                  return StreamCard(
+                    stream: streams!.data[index],
+                    onTap: (stream) {
+                      widget.onAdd?.call(stream.userLogin);
+                      setState(() {
+                        channelName = "";
+                      });
+                      Navigator.of(context).pop();
+                    },
+                  );
+                },
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/screens/home/stream_card.dart
+++ b/lib/screens/home/stream_card.dart
@@ -1,0 +1,70 @@
+import "package:chitchat/models/twitch_stream.dart";
+import "package:flutter/material.dart";
+
+class StreamCard extends StatelessWidget {
+  final TwitchStream stream;
+  final void Function(TwitchStream stream)? onTap;
+
+  const StreamCard({super.key, required this.stream, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitleStyle = TextStyle(
+      color: theme.hintColor,
+      fontSize: 13,
+    );
+
+    return ListTile(
+      title: Text(
+        stream.userName,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      isThreeLine: true,
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            stream.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                stream.gameName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: subtitleStyle,
+              ),
+              const Spacer(),
+              ClipOval(
+                child: Container(
+                  color: Colors.red.shade500,
+                  height: 7,
+                  width: 7,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Text(
+                "${stream.viewerCount} viewers",
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: subtitleStyle,
+              ),
+            ],
+          ),
+        ],
+      ),
+      onTap: () {
+        onTap?.call(stream);
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -802,7 +802,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "67b1fc567d2d1969d17ef0ce178054efbadd574d"
+      resolved-ref: "32fb078e1555fdc24e859fc8618ed00cd0265709"
       url: "https://github.com/chitchat-apps/twitch_tmi.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
- Added `TwitchStream` and `TwitchStreams` models to represent Twitch streams and their data.
- Added a new API endpoint `getFollowedStreams` to fetch followed streams from the Twitch API.
- Added StreamCard to display the followed streams